### PR TITLE
setup.py should also install sandman.model

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     author_email='jeff@jeffknupp.com',
     description='Automated REST APIs for existing database-driven systems',
     long_description=long_description,
-    packages=['sandman'],
+    packages=['sandman', 'sandman.model'],
     include_package_data=True,
     platforms='any',
     test_suite='sandman.test.test_sandman',


### PR DESCRIPTION
Currently, setup.py does not install the model module, making the sample code not work.
This simple change makes setup.py install model
