### PR TITLE
Fix to not define all the FKs/Models

### DIFF
--- a/sandman/model/utils.py
+++ b/sandman/model/utils.py
@@ -66,14 +66,15 @@ def prepare_relationships(db, known_tables):
     inspector = reflection.Inspector.from_engine(db.engine)
     for cls in set(known_tables.values()):
         for foreign_key in inspector.get_foreign_keys(cls.__tablename__):
-            other = known_tables[foreign_key['referred_table']]
-            constrained_column = foreign_key['constrained_columns']
-            if other not in cls.__related_tables__ and cls not in other.__related_tables__ and other != cls:
-                cls.__related_tables__.add(other)
-                # Add a SQLAlchemy relationship as an attribute on the class
-                setattr(cls, other.__table__.name, relationship(
-                        other.__name__, backref=db.backref(cls.__name__.lower()),
-                        foreign_keys=str(cls.__name__) + '.' + ''.join(constrained_column)))
+            if foreign_key['referred_table'] in known_tables:
+                other = known_tables[foreign_key['referred_table']]
+                constrained_column = foreign_key['constrained_columns']
+                if other not in cls.__related_tables__ and cls not in other.__related_tables__ and other != cls:
+                    cls.__related_tables__.add(other)
+                    # Add a SQLAlchemy relationship as an attribute on the class
+                    setattr(cls, other.__table__.name, relationship(
+                            other.__name__, backref=db.backref(cls.__name__.lower()),
+                            foreign_keys=str(cls.__name__) + '.' + ''.join(constrained_column)))
 
 def register(cls, use_admin=True):
     """Register with the API a :class:`sandman.model.Model` class and associated


### PR DESCRIPTION
I'm new on your codebase so this PR is more to open a discussion.

I created the scripts/models for my own project, in my case I have a DB with about 80 tables and I want to use sandman only for a subset of my models (not alls), therefore I don't want to have to define all models.

Without this patch I get error like:
    File "/home/areski/projects/Flask/sandman/sandman/model/utils.py", line 69, in prepare_relationships
        other = known_tables[foreign_key['referred_table']]
    KeyError: u'auth_user'
