### PR TITLE
Add missing reponse functions

### DIFF
--- a/sandman/decorators.py
+++ b/sandman/decorators.py
@@ -40,3 +40,15 @@ def etag(f):
                 rv = not_modified()
         return rv
     return wrapped
+
+
+def not_modified():
+    response = jsonify({'status': 304, 'error': 'not modified'})
+    response.status_code = 304
+    return response
+
+
+def precondition_failed():
+    response = jsonify({'status': 412, 'error': 'precondition failed'})
+    response.status_code = 412
+    return response


### PR DESCRIPTION
The `etag` decorator was added in a595665ab75c5995f0cb3af7463215f9cd7aabf7, following Miguel Grinberg's [`decorators` module](https://github.com/miguelgrinberg/api-pycon2014/blob/master/api/decorators.py), but the referenced [`errors` module](https://github.com/miguelgrinberg/api-pycon2014/blob/master/api/errors.py) was forgotten, causing runtime failures:

```
Traceback (most recent call last):
  File "/app/.heroku/python/lib/python2.7/site-packages/gunicorn/arbiter.py", line 495, in spawn_worker
    worker.init_process()
  File "/app/.heroku/python/lib/python2.7/site-packages/gunicorn/workers/base.py", line 106, in init_process
    self.wsgi = self.app.wsgi()
  File "/app/.heroku/python/lib/python2.7/site-packages/gunicorn/app/base.py", line 114, in wsgi
    self.callable = self.load()
  File "/app/.heroku/python/lib/python2.7/site-packages/gunicorn/app/wsgiapp.py", line 62, in load
  File "/app/.heroku/python/lib/python2.7/site-packages/gunicorn/app/wsgiapp.py", line 49, in load_wsgiapp
    return self.load_wsgiapp()
    return util.import_app(self.app_uri)
  File "/app/.heroku/python/lib/python2.7/site-packages/gunicorn/util.py", line 354, in import_app
    __import__(module)
  File "/app/sandman-on-heroku.py", line 2, in <module>
    from sandman import app
  File "/app/.heroku/python/lib/python2.7/site-packages/sandman/__init__.py", line 15, in <module>
    from . import sandman
    from .decorators import etag
  File "/app/.heroku/python/lib/python2.7/site-packages/sandman/decorators.py", line 4, in <module>
    from .errors import precondition_failed, not_modified
ImportError: No module named errors
```

The reference to `errors` was removed in 0ada6f19b416793661f102909808dd7b455d2b04, without fixing the problem.

This adds the missing response functions.
