### PR TITLE
"limit" param for collections / ability to override top level json element name

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,8 @@ register((Artist, Album, Playlist))
 ```
 
 And if you wanted to add custom logic for an endpoint? Or change the endpoint
-name? Or add validation? All supported. Here's a "fancy" class definition:
+name? Or change your top level json object name? Or add validation? All supported.
+Here's a "fancy" class definition:
 
 ```python
 class Style(Model):
@@ -172,6 +173,7 @@ class Style(Model):
     __tablename__ = 'Genre'
     __endpoint__ = 'styles'
     __methods__ = ('GET', 'DELETE')
+    __top_level_json_name__ = 'Genres'
 
     @staticmethod
     def validate_GET(resource=None):

--- a/sandman/model/models.py
+++ b/sandman/model/models.py
@@ -29,6 +29,12 @@ class Model(object):
     Default: None
     """
 
+    __top_level_json_name__ = None
+    """The top level json text to output for this class
+
+    Default: 'resources'
+    """
+
     __methods__ = ('GET', 'POST', 'PATCH', 'DELETE', 'PUT')
     """override :attr:`__methods__` if you wish to change the HTTP methods
     this :class:`sandman.model.Model` supports.

--- a/sandman/sandman.py
+++ b/sandman/sandman.py
@@ -211,6 +211,7 @@ def retrieve_collection(collection, query_arguments=None):
     if query_arguments:
         filters = []
         order = []
+        limit = None
         for key, value in query_arguments.items():
             if key == 'page':
                 continue
@@ -218,9 +219,11 @@ def retrieve_collection(collection, query_arguments=None):
                 filters.append(getattr(cls, key).like(str(value), escape='/'))
             elif key == 'sort':
                 order.append(getattr(cls, value))
+            elif key == 'limit':
+                limit = value
             elif key:
                 filters.append(getattr(cls, key) == value)
-        resources = session.query(cls).filter(*filters).order_by(*order)
+        resources = session.query(cls).filter(*filters).order_by(*order).limit(limit)
     else:
         resources = session.query(cls).all()
     return resources

--- a/tests/models.py
+++ b/tests/models.py
@@ -51,6 +51,7 @@ class Album(Model):
 
     __tablename__ = 'Album'
     __methods__ = ('POST', 'PATCH', 'DELETE', 'PUT', 'GET')
+    __top_level_json_name__ = 'Albums'
 
     def __str__(self):
         """Return string representation of *self*."""

--- a/tests/test_sandman.py
+++ b/tests/test_sandman.py
@@ -29,7 +29,7 @@ class TestSandmanBase(object):
         self.app = app.test_client()
         #pylint: disable=unused-variable
         from . import models
- 
+
     def teardown_method(self, _):
         """Remove the database file copied during setup."""
         os.unlink(self.DB_LOCATION)
@@ -71,6 +71,11 @@ class TestSandmanBasicVerbs(TestSandmanBase):
         """Test simple HTTP GET"""
         response = self.get_response('/artists', 200)
         assert len(json.loads(response.get_data(as_text=True))[u'resources']) == 275
+
+    def test_get_with_limit(self):
+        """Test simple HTTP GET"""
+        response = self.get_response('/artists', 200, params={'limit': 10})
+        assert len(json.loads(response.get_data(as_text=True))[u'resources']) == 10
 
     def test_get_with_filter(self):
         """Test simple HTTP GET"""

--- a/tests/test_sandman.py
+++ b/tests/test_sandman.py
@@ -289,6 +289,12 @@ class TestSandmanUserDefinitions(TestSandmanBase):
                       'UnitPrice': 0.99,}))
         assert response.status_code == 403
 
+    def test_responds_with_top_level_json_name_if_present(self):
+        """Test top level json element is the one defined on the Model
+        rather than the string 'resources'"""
+        response = self.get_response('/albums', 200)
+        assert len(json.loads(response.get_data(as_text=True))[u'Albums']) == 347
+
 class TestSandmanValidation(TestSandmanBase):
     """Sandman tests related to request validation"""
 


### PR DESCRIPTION
You've created an amazing tool here, thank you for that. This pull request adds:
- The ability to pass a "limit" param to collections and have the return results be limited to N
- The ability to define a top level json element name in a model class (default is "resources")

I've got a project that has worked perfectly with "out of the box" sandman with the exception of these two features. Limit seems like a no-brainer to me. The top level json element feature was to give sandman the flexibility to be consistent with the payload formats that other APIs use.

If I'm missing any tests or anything else you'd like to see, let me know, I'd be happy to follow up on your feedback!

Thanks again for this cool tool,
Scott
