### PR TITLE
Add note to README about using absolute paths

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,11 @@ database using ``sandman``:
 .. code:: bash
 
     $ sandmanctl sqlite:////tmp/my_database.db
+    
+**Use an absolute path to the database or a 'full' URI** such as:
+   - postgresql+psycopg2://scott:tiger@localhost/test
+   - sqlite+pysqlite:///relative/path/to/db.db
+
 
 *That's it.* ``sandman`` will then do the following:
 


### PR DESCRIPTION
This issue bit me for a while until I started searching through old issues and found these issues:
- https://github.com/jeffknupp/sandman/issues/34
- https://github.com/jeffknupp/sandman/issues/46

This commit seemed to make this issue more clear but I guess this was lost when switching to the click library for command-line parsing.
- https://github.com/jeffknupp/sandman/commit/34406d3797dd567647b78e0cf6a030a4299d68fa
