### PR TITLE
Include templates and static files on install.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include sandman/static *
+recursive-include sandman/templates *


### PR DESCRIPTION
Include templates and static files using `MANIFEST.in`. Including files using `package_data` in `setup.py` doesn't include them on `pip install`. See http://blog.codekills.net/2011/07/15/lies,-more-lies-and-python-packaging-documentation-on--package_data-/.
