### PR TITLE
Fix tests for current package versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: python
 python:
   - "2.7"
-install: 
-    - "pip install -r requirements.txt --use-mirrors"
-    - "pip install coverage"
-    - "pip install coveralls"
-script: 
-    - "coverage run --source=sandman setup.py test"
+install:
+  - python setup.py develop
+  - pip install coverage
+  - pip install coveralls
+script:
+  - coverage run --source=sandman setup.py test
 after_success:
     coveralls


### PR DESCRIPTION
There are currently two sets of dependency versions for sandman: one set
of pinned versions in `requirements.txt` and another set of unpinned
versions in `setup.py`. This means that installing via `pip` installs
the latest versions of the dependencies, but installing from
`requirements.txt` installs older, pinned versions. Several tests fail
with the latest versions of Flask-Admin and Flask-WTForms.

This patch fixes the breaking tests and installs tests on Travis using
`setup.py` for consistency.
