### PR TITLE
Custom base class

### DIFF
--- a/sandman/sandman.py
+++ b/sandman/sandman.py
@@ -188,7 +188,7 @@ def _validate(cls, method, resource=None):
 
     """
     if method not in cls.__methods__:
-        raise InvalidAPIUsage(403, FORBIDDEN_EXCEPTION_MESSAGE.format(
+        raise InvalidAPIUsage(405, FORBIDDEN_EXCEPTION_MESSAGE.format(
             method,
             cls.endpoint(), cls.__methods__))
 

--- a/tests/test_sandman.py
+++ b/tests/test_sandman.py
@@ -301,25 +301,25 @@ class TestSandmanValidation(TestSandmanBase):
     def test_delete_not_supported(self):
         """Test DELETEing a resource for an endpoint that doesn't support it."""
         response = self.app.delete('/playlists/1')
-        assert response.status_code == 403
+        assert response.status_code == 405
 
     def test_unsupported_patch_resource(self):
         """Test PATCHing a resource for an endpoint that doesn't support it."""
         response = self.app.patch('/styles/26',
                 content_type='application/json',
                 data=json.dumps({u'Name': u'Hip-Hop'}))
-        assert response.status_code == 403
+        assert response.status_code == 405
 
     def test_unsupported_get_resource(self):
         """Test GETing a resource for an endpoint that doesn't support it."""
-        self.get_response('/playlists', 403, False)
+        self.get_response('/playlists', 405, False)
 
     def test_unsupported_collection_method(self):
         """Test POSTing a collection for an endpoint that doesn't support it."""
         response = self.app.post('/styles',
                 content_type='application/json',
                 data=json.dumps({u'Name': u'Jeff Knupp'}))
-        assert response.status_code == 403
+        assert response.status_code == 405
 
     def test_pagination(self):
         """Can we get paginated results?"""


### PR DESCRIPTION
Users may want to customize default behavior (e.g., making a read-only API by setting the default `__methods__` to `('GET', )`). This patch adds an optional `base` parameter to `activate` to support this use case. Requests with unsupported methods are also updated to return HTTP 405 (method not allowed) instead of 403 (forbidden).
