### PR TITLE
Add deprecation message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-sandman
-=======
+This version is obsolete, please consider to use https://github.com/jeffknupp/sandman2
+======================================================================================
 
 [![Build Status](https://travis-ci.org/jeffknupp/sandman.png?branch=develop)](https://travis-ci.org/jeffknupp/sandman)
 


### PR DESCRIPTION
People still create issues for this obsolete version.
Furthermore, I have started my project with this obsolete version because there is no information about sandman2 in this repo.
I think that add deprecation message to README is a good idea.
